### PR TITLE
Update examples to Go 1.17

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,11 +5,7 @@ Check out each folder for mor information.
 
 ## Building and Running the Examples
 
-1. Run `go get -u golang.org/x/sys/windows` to make sure you have it in your `GOPATH`.
-2. Run `go build` in the example folders to build the executable.
-3. Run the `.exe` to test the program.
-
-*Note*: I've only tested this on Go 1.15. I see no reason why this wouldn't work on 1.14 though.
+Run `.\build.ps1`, the commands will be built into the `.\bin` folder
 
 ## Unsafe Operations
 

--- a/build.ps1
+++ b/build.ps1
@@ -1,0 +1,35 @@
+#!powershell
+[CmdletBinding()]
+param (
+    [Parameter(Position=0)]
+    [ValidateSet(
+        "all",
+        "credenumeratew_managed",
+        "credenumeratew_unmanaged",
+        "netstat",
+        "networkparams",
+        "unsafe_cast")]
+    [string]
+    $Command="all"
+)
+
+function Build-Command {
+    param(
+        [string]$Command
+    )
+    if ( -not (Test-Path -Path ".\bin") ) {
+        New-Item -Path ".\bin" -ItemType Directory
+    }
+    Write-Host "Building: ${command}"
+    & go build -o ".\bin\${command}.exe" ".\${command}" 
+}
+
+if ($Command -eq "all") {
+    Build-Command -Command "credenumeratew_managed"
+    Build-Command -Command "credenumeratew_unmanaged"
+    Build-Command -Command "netstat"
+    Build-Command -Command "networkparams"
+    Build-Command -Command "unsafe_cast"
+} else {
+    Build-Command -Command $Command
+}

--- a/credenumeratew_managed/credentials.go
+++ b/credenumeratew_managed/credentials.go
@@ -78,7 +78,7 @@ func toCredential(pcred *_CREDENTIALW) (credential Credential) {
 	if pcred.CredentialBlobSize > 0 {
 		n := int(pcred.CredentialBlobSize)
 		val := make([]byte, n)
-		copy(val, (*(*[1 << 30]byte)(unsafe.Pointer(pcred.CredentialBlob)))[0:n:n])
+		copy(val, unsafe.Slice(pcred.CredentialBlob, n))
 		credential.Credential = val
 	}
 	if pcred.AttributeCount > 0 {

--- a/credenumeratew_managed/syscall_windows.go
+++ b/credenumeratew_managed/syscall_windows.go
@@ -11,7 +11,7 @@ import (
 //sys FileTimeToSystemTime(fileTime *_FILETIME, systemTime *_SYSTEMTIME) [failretval==0] (err error) = kernel32.FileTimeToSystemTime
 
 // UTF16PtrFromString converts a string to a UTF-16 C-String
-func UTF16PtrFromString(str string) (*uint16,error) {
+func UTF16PtrFromString(str string) (*uint16, error) {
 	return syscall.UTF16PtrFromString(str)
 }
 
@@ -29,7 +29,7 @@ func UTF16PtrToString(p *uint16) string {
 		end = unsafe.Pointer(uintptr(end) + wcharSize)
 		n++
 	}
-	// Convert *uint16 to []uint16 via *[1 << 30]uint16
-	wstr := (*[1 << 30]uint16)(unsafe.Pointer(p))[:n:n]
+	// Convert *uint16 to []uint16
+	wstr := unsafe.Slice(p, n)
 	return string(utf16.Decode(wstr))
 }

--- a/credenumeratew_unmanaged/credentials.go
+++ b/credenumeratew_unmanaged/credentials.go
@@ -96,7 +96,7 @@ func (c *Credential) Credential() []byte {
 		return nil
 	}
 	n := int(c.pcred.CredentialBlobSize)
-	return (*[1 << 30]byte)(unsafe.Pointer(c.pcred.CredentialBlob))[0:n:n]
+	return unsafe.Slice(c.pcred.CredentialBlob, n)
 }
 
 func (c *Credential) LastWritten() time.Time {

--- a/credenumeratew_unmanaged/syscall_windows.go
+++ b/credenumeratew_unmanaged/syscall_windows.go
@@ -11,7 +11,7 @@ import (
 //sys FileTimeToSystemTime(fileTime *_FILETIME, systemTime *_SYSTEMTIME) [failretval==0] (err error) = kernel32.FileTimeToSystemTime
 
 // UTF16PtrFromString converts a string to a UTF-16 C-String
-func UTF16PtrFromString(str string) (*uint16,error) {
+func UTF16PtrFromString(str string) (*uint16, error) {
 	return syscall.UTF16PtrFromString(str)
 }
 
@@ -29,7 +29,7 @@ func UTF16PtrToString(p *uint16) string {
 		end = unsafe.Pointer(uintptr(end) + wcharSize)
 		n++
 	}
-	// Convert *uint16 to []uint16 via *[1 << 30]uint16
-	wstr := (*[1 << 30]uint16)(unsafe.Pointer(p))[:n:n]
+	// Convert *uint16 to []uint16
+	wstr := unsafe.Slice(p, n)
 	return string(utf16.Decode(wstr))
 }

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,5 @@
+module github.com/justenwalker/gophercon-2020-winapi
+
+go 1.17
+
+require golang.org/x/sys v0.0.0-20210816183151-1e6c022a8912

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,2 @@
+golang.org/x/sys v0.0.0-20210816183151-1e6c022a8912 h1:uCLL3g5wH2xjxVREVuAbP9JM5PPKjRbXKRa6IBjkzmU=
+golang.org/x/sys v0.0.0-20210816183151-1e6c022a8912/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=

--- a/netstat/tcptable.go
+++ b/netstat/tcptable.go
@@ -42,7 +42,7 @@ func convertToTableRows(raw []byte) (result []TableRow) {
 		return
 	}
 	result = make([]TableRow, n)
-	rows := (*[1 << 30]_MIB_TCPROW_OWNER_PID)(unsafe.Pointer(&table.Table))[0:n:n]
+	rows := unsafe.Slice(&table.Table[0], table.NumEntries)
 	for i, row := range rows {
 		result[i] = TableRow{
 			Local:  convertToTCPv4Addr(row.LocalAddr, row.LocalPort),


### PR DESCRIPTION
- Convert to go modules
- Add a helper build.ps1 script to build the example commands
- Update examples to use the `unsafe.Add` and `unsafe.Slice` functions introduced by Go 1.17
- Update the README to refer to both old and new methods of doing pointer arithmetic and pointer to slice conversions
